### PR TITLE
feat: allow any type that implements View(), not just tea.Model

### DIFF
--- a/model.go
+++ b/model.go
@@ -18,19 +18,15 @@ const (
 	Center
 )
 
-type Foreground interface {
-	View() string
-}
-
-type Background interface {
+type Viewable interface {
 	View() string
 }
 
 // Model implements tea.Model, and manages calculating and compositing the overlay UI from the
 // backbround and foreground models.
 type Model struct {
-	Foreground Foreground
-	Background Background
+	Foreground Viewable
+	Background Viewable
 	XPosition  Position
 	YPosition  Position
 	XOffset    int
@@ -38,7 +34,7 @@ type Model struct {
 }
 
 // New creates, instantiates, and returns a pointer to a new overlay Model.
-func New(fore Foreground, back Background, xPos Position, yPos Position, xOff int, yOff int) *Model {
+func New(fore Viewable, back Viewable, xPos Position, yPos Position, xOff int, yOff int) *Model {
 	return &Model{
 		Foreground: fore,
 		Background: back,


### PR DESCRIPTION
Hey!
Thanks for the project, it works nice and simply, exactly solves the use case I had.

I have some models [in my project](https://github.com/encephala/terminaccounting) that mimic `tea.Model`.
One such model is called `appManager`. I say "mimic", because a slight difference is that I prefer having [`Update(msg tea.Msg) (*appManager, error)`](https://github.com/Encephala/terminaccounting/blob/8099915be236abc5960a0c7661cd2f2ee4f39f44/src/appmanager.go#L36), where I return the model type itself instead of `tea.Model`, because that means I don't have to add a whole bunch of type assertions in my code.

Now the trouble is that the `overlay.Model` explicitly requires `tea.Model`. I thus can't use the overlay with my `*appManager`, because the `Update` function doesn't have the same signature as `tea.Model.Update`. 

As far as I can tell, only the `View() string` function is required. It makes sense to me to relax the constraint in the `overlay.Model` to only require the `View() string` function, as I do in this PR.